### PR TITLE
cusp: remove templates from conj, complex_to_

### DIFF
--- a/include/cusp/complex_to_mag.cuh
+++ b/include/cusp/complex_to_mag.cuh
@@ -6,12 +6,11 @@
 namespace cusp
 {
 
-template <typename T>
 class complex_to_mag : public kernel
 {
 public:
     complex_to_mag() = default;
-    cudaError_t launch(const T *in, T *out, int grid_size, int block_size,
+    cudaError_t launch(const std::complex<float> *in, float *out, int grid_size, int block_size,
         int N, cudaStream_t stream = 0);
     virtual cudaError_t launch(const std::vector<const void *> inputs,
         const std::vector<void *> outputs, size_t nitems) override;

--- a/include/cusp/complex_to_mag_squared.cuh
+++ b/include/cusp/complex_to_mag_squared.cuh
@@ -1,17 +1,15 @@
 #pragma once
 
 #include <cusp/kernel.cuh>
-#include <thrust/complex.h>
 
 namespace cusp
 {
 
-template <typename T>
 class complex_to_mag_squared : public kernel
 {
 public:
     complex_to_mag_squared() = default;
-    cudaError_t launch(const T *in, T *out, int grid_size, int block_size,
+    cudaError_t launch(const std::complex<float> *in, float *out, int grid_size, int block_size,
         int N, cudaStream_t stream = 0);
     virtual cudaError_t launch(const std::vector<const void *> inputs,
         const std::vector<void *> outputs, size_t nitems) override;

--- a/include/cusp/conjugate.cuh
+++ b/include/cusp/conjugate.cuh
@@ -1,17 +1,16 @@
 #pragma once
 
 #include <cusp/kernel.cuh>
-#include <thrust/complex.h>
+#include <complex>
 
 namespace cusp
 {
 
-template <typename T>
 class conjugate : public kernel
 {
 public:
     conjugate() = default;
-    cudaError_t launch(const T *in, T *out, int grid_size, int block_size,
+    cudaError_t launch(const std::complex<float> *in, std::complex<float> *out, int grid_size, int block_size,
         int N, cudaStream_t stream = 0);
     virtual cudaError_t launch(const std::vector<const void *> inputs,
         const std::vector<void *> outputs, size_t nitems) override;

--- a/kernels/conjugate.cu
+++ b/kernels/conjugate.cu
@@ -2,18 +2,18 @@
 #include <cuda_runtime.h>
 #include "helper_cuda.h"
 #include <cusp/conjugate.cuh>
+#include <thrust/complex.h>
 
 namespace cusp {
 
-template <typename T> __global__ void kernel_conjugate(const T *in, T *out, int N) {
+__global__ void kernel_conjugate(const thrust::complex<float> *in, thrust::complex<float> *out, int N) {
   int i = blockIdx.x * blockDim.x + threadIdx.x;
   if (i < N) {
     out[i] = thrust::complex<float>(in[i].real(), -1.0 * in[i].imag());
   }
 }
 
-template <typename T>
-cudaError_t conjugate<T>::launch(const T *in, T *out, int N, int grid_size, int block_size,
+cudaError_t conjugate::launch(const std::complex<float> *in, std::complex<float> *out, int N, int grid_size, int block_size,
                   cudaStream_t stream) {
   if (stream) {
     kernel_conjugate<<<grid_size, block_size, 0, stream>>>((const thrust::complex<float> *)in, 
@@ -25,19 +25,15 @@ cudaError_t conjugate<T>::launch(const T *in, T *out, int N, int grid_size, int 
   return cudaPeekAtLastError();
 }
 
-template <typename T>
-cudaError_t conjugate<T>::launch(const std::vector<const void *> inputs,
+cudaError_t conjugate::launch(const std::vector<const void *> inputs,
                   const std::vector<void *> outputs, size_t nitems) {
-  return launch((const T*)inputs[0], (T*)outputs[0], nitems, _grid_size, _block_size, _stream);
+  return launch((const std::complex<float> *)inputs[0], (std::complex<float> *)outputs[0], nitems, _grid_size, _block_size, _stream);
 }
 
-template <typename T> cudaError_t conjugate<T>::occupancy(int *minBlock, int *minGrid) {
+cudaError_t conjugate::occupancy(int *minBlock, int *minGrid) {
   return cudaOccupancyMaxPotentialBlockSize(minGrid, minBlock,
-                                            kernel_conjugate<thrust::complex<float>>, 0, 0);
+                                            kernel_conjugate, 0, 0);
 }
 
-#define IMPLEMENT_KERNEL(T) template class conjugate<T>;
-
-IMPLEMENT_KERNEL(std::complex<float>)
 
 } // namespace cusp

--- a/test/qa_complex_to_mag.cu
+++ b/test/qa_complex_to_mag.cu
@@ -5,28 +5,26 @@
 
 using namespace cusp;
 
-template <typename T> 
 void run_test(int N)
 {
     std::vector<std::complex<float>> host_input_data(N);
-    std::vector<std::complex<float>> expected_output_data(N);
+    std::vector<float> expected_output_data(N);
     for (int i = 0; i < N; i++) {
       host_input_data[i] = std::complex<float>(float(i), float(i * 2));
-      float mag = sqrtf(powf(host_input_data[i].real(), 2) + powf(host_input_data[i].imag(), 2));
-      expected_output_data[i] = std::complex<float>(mag, 0.0f);
+      expected_output_data[i] = sqrtf(powf(host_input_data[i].real(), 2) + powf(host_input_data[i].imag(), 2));
     }
-    std::vector<std::complex<float>> host_output_data(N);
+    std::vector<float> host_output_data(N);
   
     void *dev_input_data;
     void *dev_output_data;
   
     cudaMalloc(&dev_input_data, N * sizeof(std::complex<float>));
-    cudaMalloc(&dev_output_data, N * sizeof(std::complex<float>));
+    cudaMalloc(&dev_output_data, N * sizeof(float));
   
     cudaMemcpy(dev_input_data, host_input_data.data(),
                N * sizeof(std::complex<float>), cudaMemcpyHostToDevice);
   
-    cusp::complex_to_mag<std::complex<float>> op;
+    cusp::complex_to_mag op;
     int minGrid, blockSize, gridSize;
     op.occupancy(&blockSize, &minGrid);
     gridSize = (N + blockSize - 1) / blockSize;
@@ -35,13 +33,13 @@ void run_test(int N)
   
     cudaDeviceSynchronize();
     cudaMemcpy(host_output_data.data(), dev_output_data,
-               N * sizeof(std::complex<float>), cudaMemcpyDeviceToHost);
+               N * sizeof(float), cudaMemcpyDeviceToHost);
   
-    //EXPECT_EQ(expected_output_data, host_output_data);
-    for (int i = 0; i < (int)expected_output_data.size(); i++) {
-      EXPECT_NEAR(expected_output_data[i].real(),
-                  host_output_data[i].real(),
-                  expected_output_data[i].real() / 10000);
+    // EXPECT_EQ(expected_output_data, host_output_data);
+    for (size_t i = 0; i < expected_output_data.size(); i++) {
+      EXPECT_NEAR(expected_output_data[i],
+                  host_output_data[i],
+                  expected_output_data[i] / 10000);
     }
 }
 
@@ -49,5 +47,5 @@ void run_test(int N)
 TEST(ComplexToMagKernel, Basic) {
   int N = 1024 * 100;
 
-  run_test<std::complex<float>>(N);
+  run_test(N);
 }

--- a/test/qa_complex_to_mag_squared.cu
+++ b/test/qa_complex_to_mag_squared.cu
@@ -5,17 +5,15 @@
 
 using namespace cusp;
 
-template <typename T> 
 void run_test(int N)
 {
-    std::vector<std::complex<float>> host_input_data(N);
-    std::vector<std::complex<float>> expected_output_data(N);
+  std::vector<std::complex<float>> host_input_data(N);
+  std::vector<float> expected_output_data(N);
     for (int i = 0; i < N; i++) {
       host_input_data[i] = std::complex<float>(float(i), float(i * 2));
-      float mag = powf(host_input_data[i].real(), 2) + powf(host_input_data[i].imag(), 2);
-      expected_output_data[i] = std::complex<float>(mag, 0.0f);
+      expected_output_data[i] = powf(host_input_data[i].real(), 2) + powf(host_input_data[i].imag(), 2);
     }
-    std::vector<std::complex<float>> host_output_data(N);
+    std::vector<float> host_output_data(N);
   
     void *dev_input_data;
     void *dev_output_data;
@@ -26,7 +24,7 @@ void run_test(int N)
     cudaMemcpy(dev_input_data, host_input_data.data(),
                N * sizeof(std::complex<float>), cudaMemcpyHostToDevice);
   
-    cusp::complex_to_mag_squared<std::complex<float>> op;
+    cusp::complex_to_mag_squared op;
     int minGrid, blockSize, gridSize;
     op.occupancy(&blockSize, &minGrid);
     gridSize = (N + blockSize - 1) / blockSize;
@@ -35,13 +33,12 @@ void run_test(int N)
   
     cudaDeviceSynchronize();
     cudaMemcpy(host_output_data.data(), dev_output_data,
-               N * sizeof(std::complex<float>), cudaMemcpyDeviceToHost);
+               N * sizeof(float), cudaMemcpyDeviceToHost);
   
-    //EXPECT_EQ(expected_output_data, host_output_data);
-    for (int i = 0; i < (int)expected_output_data.size(); i++) {
-      EXPECT_NEAR(expected_output_data[i].real(),
-                  host_output_data[i].real(),
-                  expected_output_data[i].real() / 10000);
+    for (size_t i = 0; i < expected_output_data.size(); i++) {
+      EXPECT_NEAR(expected_output_data[i],
+                  host_output_data[i],
+                  expected_output_data[i] / 10000);
     }
 }
 
@@ -49,5 +46,5 @@ void run_test(int N)
 TEST(ComplexToMagSquaredKernel, Basic) {
   int N = 1024 * 100;
 
-  run_test<std::complex<float>>(N);
+  run_test(N);
 }

--- a/test/qa_conjugate.cu
+++ b/test/qa_conjugate.cu
@@ -26,7 +26,7 @@ void run_test(int N)
     cudaMemcpy(dev_input_data, host_input_data.data(),
                N * sizeof(std::complex<float>), cudaMemcpyHostToDevice);
   
-    cusp::conjugate<std::complex<float>> op;
+    cusp::conjugate op;
     int minGrid, blockSize, gridSize;
     op.occupancy(&blockSize, &minGrid);
     gridSize = (N + blockSize - 1) / blockSize;


### PR DESCRIPTION
Removing templates from kernels that don't need them (will never be different)

Signed-off-by: Josh Morman <jmorman@perspectalabs.com>